### PR TITLE
compat+docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,5 +60,6 @@ Destiny2.getProfile(...);
 # Build
 
 ```
+git submodule update --init --recursive
 yarn && yarn start
 ```

--- a/build.sh
+++ b/build.sh
@@ -29,5 +29,5 @@ cp package.json lib/
 cp README.md lib/
 cp bungie-api-LICENSE lib/
 
-sed -i '' 's/dist\///' lib/package.json
-sed -i '' 's/index\.ts/index.js/' lib/package.json
+sed --in-place='' 's/dist\///' lib/package.json
+sed --in-place='' 's/index\.ts/index.js/' lib/package.json

--- a/generator/generate-common.ts
+++ b/generator/generate-common.ts
@@ -62,6 +62,7 @@ export function generateImports(
       if (!relativePath.startsWith('.')) {
         relativePath = './' + relativePath;
       }
+      if (path.sep === '\\') relativePath = relativePath.replace(/\\/g, '/');
       return `import {
   ${[...types].sort().join(',\n  ')}
 } from '${relativePath}';`;


### PR DESCRIPTION
@bhollis  can you test out whether this sed format works? my bash interprets
`-i ''` as `''` being a path. which is i think technically correct. not sure if it's coded as an exception for macs.
this syntax seems clearer about its intentions, i'm hoping mac understands it

this normalizes windows file paths

also: would it be correct to say this requires globally installed `babel-cli` and `typedoc`? it seems to