### PR TITLE
mark components as required

### DIFF
--- a/generated-src/destiny2/api.ts
+++ b/generated-src/destiny2/api.ts
@@ -171,7 +171,7 @@ export interface GetProfileParams {
    * See the DestinyComponentType enum for valid components to request. You must
    * request at least one component to receive results.
    */
-  components?: DestinyComponentType[];
+  components: DestinyComponentType[];
   /** Destiny membership ID. */
   destinyMembershipId: string;
   /** A valid non-BungieNet membership type. */
@@ -197,7 +197,7 @@ export interface GetCharacterParams {
    * See the DestinyComponentType enum for valid components to request. You must
    * request at least one component to receive results.
    */
-  components?: DestinyComponentType[];
+  components: DestinyComponentType[];
   /** Destiny membership ID. */
   destinyMembershipId: string;
   /** A valid non-BungieNet membership type. */
@@ -237,7 +237,7 @@ export interface GetItemParams {
    * See the DestinyComponentType enum for valid components to request. You must
    * request at least one component to receive results.
    */
-  components?: DestinyComponentType[];
+  components: DestinyComponentType[];
   /** The membership ID of the destiny profile. */
   destinyMembershipId: string;
   /** The Instance ID of the destiny item. */
@@ -269,7 +269,7 @@ export interface GetVendorsParams {
    * See the DestinyComponentType enum for valid components to request. You must
    * request at least one component to receive results.
    */
-  components?: DestinyComponentType[];
+  components: DestinyComponentType[];
   /** Destiny membership ID of another user. You may be denied. */
   destinyMembershipId: string;
   /** The filter of what vendors and items to return, if any. */
@@ -303,7 +303,7 @@ export interface GetVendorParams {
    * See the DestinyComponentType enum for valid components to request. You must
    * request at least one component to receive results.
    */
-  components?: DestinyComponentType[];
+  components: DestinyComponentType[];
   /** Destiny membership ID of another user. You may be denied. */
   destinyMembershipId: string;
   /** A valid non-BungieNet membership type. */
@@ -329,7 +329,7 @@ export interface GetPublicVendorsParams {
    * See the DestinyComponentType enum for valid components to request. You must
    * request at least one component to receive results.
    */
-  components?: DestinyComponentType[];
+  components: DestinyComponentType[];
 }
 
 /**
@@ -366,7 +366,7 @@ export interface GetCollectibleNodeDetailsParams {
    * See the DestinyComponentType enum for valid components to request. You must
    * request at least one component to receive results.
    */
-  components?: DestinyComponentType[];
+  components: DestinyComponentType[];
   /** Destiny membership ID of another user. You may be denied. */
   destinyMembershipId: string;
   /** A valid non-BungieNet membership type. */

--- a/generator/generate-api.ts
+++ b/generator/generate-api.ts
@@ -156,7 +156,11 @@ function generateInterfaceSchema(
     const paramType = resolveSchemaType(param.schema!, doc);
     addImport(doc, param.schema!, componentByDef, importFiles);
     const docString = param.description ? docComment(param.description) + '\n' : '';
-    return `${docString}${param.name}${param.required ? '' : '?'}: ${paramType};`;
+    return `${docString}${param.name}${
+      param.required || (param.name === 'components' && paramType === 'DestinyComponentType[]')
+        ? ''
+        : '?'
+    }: ${paramType};`;
   });
 
   return `export interface ${interfaceName} {

--- a/lib/destiny2/api.d.ts
+++ b/lib/destiny2/api.d.ts
@@ -141,7 +141,7 @@ export interface GetProfileParams {
    * See the DestinyComponentType enum for valid components to request. You must
    * request at least one component to receive results.
    */
-  components?: DestinyComponentType[];
+  components: DestinyComponentType[];
   /** Destiny membership ID. */
   destinyMembershipId: string;
   /** A valid non-BungieNet membership type. */
@@ -160,7 +160,7 @@ export interface GetCharacterParams {
    * See the DestinyComponentType enum for valid components to request. You must
    * request at least one component to receive results.
    */
-  components?: DestinyComponentType[];
+  components: DestinyComponentType[];
   /** Destiny membership ID. */
   destinyMembershipId: string;
   /** A valid non-BungieNet membership type. */
@@ -189,7 +189,7 @@ export interface GetItemParams {
    * See the DestinyComponentType enum for valid components to request. You must
    * request at least one component to receive results.
    */
-  components?: DestinyComponentType[];
+  components: DestinyComponentType[];
   /** The membership ID of the destiny profile. */
   destinyMembershipId: string;
   /** The Instance ID of the destiny item. */
@@ -214,7 +214,7 @@ export interface GetVendorsParams {
    * See the DestinyComponentType enum for valid components to request. You must
    * request at least one component to receive results.
    */
-  components?: DestinyComponentType[];
+  components: DestinyComponentType[];
   /** Destiny membership ID of another user. You may be denied. */
   destinyMembershipId: string;
   /** The filter of what vendors and items to return, if any. */
@@ -240,7 +240,7 @@ export interface GetVendorParams {
    * See the DestinyComponentType enum for valid components to request. You must
    * request at least one component to receive results.
    */
-  components?: DestinyComponentType[];
+  components: DestinyComponentType[];
   /** Destiny membership ID of another user. You may be denied. */
   destinyMembershipId: string;
   /** A valid non-BungieNet membership type. */
@@ -259,7 +259,7 @@ export interface GetPublicVendorsParams {
    * See the DestinyComponentType enum for valid components to request. You must
    * request at least one component to receive results.
    */
-  components?: DestinyComponentType[];
+  components: DestinyComponentType[];
 }
 /**
  * Get items available from vendors where the vendors have items for sale that are
@@ -289,7 +289,7 @@ export interface GetCollectibleNodeDetailsParams {
    * See the DestinyComponentType enum for valid components to request. You must
    * request at least one component to receive results.
    */
-  components?: DestinyComponentType[];
+  components: DestinyComponentType[];
   /** Destiny membership ID of another user. You may be denied. */
   destinyMembershipId: string;
   /** A valid non-BungieNet membership type. */


### PR DESCRIPTION
components array is incorrectly left optional in the API spec, when it's required for any useful return value, which is noted in the comments themselves