### PR TITLE
Auto publish to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: NPM Publish
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      # This will only publish if the package.json version has changed
+      - name: Check version changes
+        uses: EndBug/version-check@v1 # More info about the arguments on the action page
+        id: check # This will be the reference for later
+
+      - name: Setup Node
+        if: steps.check.outputs.changed == 'true'
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: Publish the package to NPM
+        if: steps.check.outputs.changed == 'true'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # NPM will automatically authenticate with this

--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ yarn && yarn submodule
 # run
 yarn start
 ```
+
+# Publishing
+
+Update the version in `package.json`, and when the PR merges to `master`, a GitHub workflow will automatically publish to NPM. Don't forget to run `yarn start` and commit all changed files!

--- a/lib/README.md
+++ b/lib/README.md
@@ -87,3 +87,7 @@ yarn && yarn submodule
 # run
 yarn start
 ```
+
+# Publishing
+
+Update the version in `package.json`, and when the PR merges to `master`, a GitHub workflow will automatically publish to NPM. Don't forget to run `yarn start` and commit all changed files!


### PR DESCRIPTION
This *should* automatically publish new versions to NPM as long as the version in `package.json` is updated.