### PR TITLE
make itemValueVisibility property nullable to reflect api data

### DIFF
--- a/generated-src/destiny2/interfaces.ts
+++ b/generated-src/destiny2/interfaces.ts
@@ -8666,7 +8666,7 @@ export interface DestinyItemComponent {
    * If available, a list that describes which item values (rewards) should be shown (
    * true) or hidden (false).
    */
-  readonly itemValueVisibility: boolean[];
+  readonly itemValueVisibility?: boolean[];
 }
 
 export const enum ItemBindStatus {
@@ -13028,7 +13028,7 @@ export interface DestinyVendorSaleItemComponent {
    * If available, a list that describes which item values (rewards) should be shown (
    * true) or hidden (false).
    */
-  readonly itemValueVisibility: boolean[];
+  readonly itemValueVisibility?: boolean[];
   /**
    * The index into the DestinyVendorDefinition.itemList property. Note that this
    * means Vendor data *is* Content Version dependent: make sure you have the latest

--- a/generator/generate-interfaces.ts
+++ b/generator/generate-interfaces.ts
@@ -15,7 +15,7 @@ import { missingPropsByInterfaceName } from './missing-props.js';
  * Some properties aren't marked as nullable in the openapi docs, but they are frequently null in practice and cause trouble.
  * Adding a property to this list forces it to be emitted as nullable.
  */
-const frequentlyNullProperties = ['itemCategoryHashes'];
+const frequentlyNullProperties = ['itemCategoryHashes', 'itemValueVisibility'];
 
 export function generateInterfaceDefinitions(
   file: string,

--- a/lib/destiny2/interfaces.d.ts
+++ b/lib/destiny2/interfaces.d.ts
@@ -8428,7 +8428,7 @@ export interface DestinyItemComponent {
    * If available, a list that describes which item values (rewards) should be shown (
    * true) or hidden (false).
    */
-  readonly itemValueVisibility: boolean[];
+  readonly itemValueVisibility?: boolean[];
 }
 export declare const enum ItemBindStatus {
   NotBound = 0,
@@ -12735,7 +12735,7 @@ export interface DestinyVendorSaleItemComponent {
    * If available, a list that describes which item values (rewards) should be shown (
    * true) or hidden (false).
    */
-  readonly itemValueVisibility: boolean[];
+  readonly itemValueVisibility?: boolean[];
   /**
    * The index into the DestinyVendorDefinition.itemList property. Note that this
    * means Vendor data *is* Content Version dependent: make sure you have the latest


### PR DESCRIPTION
this prop is present in very few invitems/vendor items, and docs say "if available, contains"